### PR TITLE
Accept asset IDs, Paths & URLs as parameters

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,23 @@ This add-on provides a number of tags:
 
 ### Outputting a BlurHash image
 
- `{{ blur_hash:image }}` or `{{ blur_hash image="path_or_asset" }}`
+ `{{ blur_hash:image }}` 
+
+or 
+
+`{{ blur_hash :image="asset" }}` 
+
+or 
+
+`{{ blur_hash :url="url" }}` 
+
+or
+
+`{{ blur_hash :id="asset_id" }}`
+
+or 
+
+`{{ blur_hash :path="local_path" }}`
 
 This tag will output an encoded image in the following format:
 
@@ -55,6 +71,18 @@ it will then be found at `resources/views/vendor/statamic-blurhash/output.blade.
 ### Encoding a BlurHash image
 
 `{{ blur_hash:encode image="path_or_asset" }}`
+
+or
+
+`{{ blur_hash:encode :url="url" }}`
+
+or
+
+`{{ blur_hash:encode :id="asset_id" }}`
+
+or
+
+`{{ blur_hash:encode :path="path" }}`
 
 This will return a BlurHash encoded URL, useful if you want to return this to JavaScript or a 3rd party service (such as Algolia).
 

--- a/src/Tags/BlurHash.php
+++ b/src/Tags/BlurHash.php
@@ -19,8 +19,10 @@ class BlurHash extends Tags
      *
      * @return string|array
      */
-    public function encode($image)
+    public function encode()
     {
+        $image = $this->getImageFromParams();
+        
         if ($image instanceof AssetContract) {
             $this->dimensions = $image->dimensions();
 
@@ -57,21 +59,7 @@ class BlurHash extends Tags
      */
     public function index()
     {
-        $image = $this->params->get('image');
-
-        if ($id = $this->params->get('id')) {
-            $image = Asset::findById($id);
-        }
-
-        if ($path = $this->params->get('path')) {
-            $image = Asset::findByPath($path);
-        }
-
-        if ($url = $this->params->get('url')) {
-            $image = Asset::findByUrl($url);
-        }
-
-        $hash = $this->encode($image);
+        $hash = $this->encode();
 
         if ($this->dimensions) {
             $width = $this->params->get('width', 0);
@@ -104,5 +92,34 @@ class BlurHash extends Tags
         $this->params->put('image', $this->context->value($tag));
 
         return $this->index();
+    }
+    
+    private function getImageFromParams()
+    {
+        if ($id = $this->params->get('id')) {
+            $image = Asset::findById($id);
+                
+            if ($image) {
+                return $image;
+            }
+        }
+
+        if ($path = $this->params->get('path')) {
+            $image = Asset::findByPath($path);
+                
+            if ($image) {
+                return $image;
+            }
+        }
+
+        if ($url = $this->params->get('url')) {
+            $image = Asset::findByUrl($url);
+                
+            if ($image) {
+                return $image;
+            }
+        }
+        
+        return $this->params->get('image');
     }
 }


### PR DESCRIPTION
I'm currently implementing this into my site but had some issues using the tag without already having an instance of an asset.

In my case, I'm looping through images from an Assets field. 

```antlers
{{ images }}
    {{ blur_hash :image="url" }}
{{ /images }}
```

However, if I try to provide a `url`/`id`/`path` as the `image` parameter, I get the error reported in #1.

This pull request introduces three new parameters to the tag to allow passing in either the ID / Path / URL of an asset. The tag will then find the asset based on that info, then pass it along to the `encode` method.